### PR TITLE
Fix init-static-github test

### DIFF
--- a/test/init-static-github/test.nix
+++ b/test/init-static-github/test.nix
@@ -8,7 +8,7 @@
     cd ./root
 
     error_ignore
-    step_nix run "github:tek/hix#new" -- --name 'red-panda'
+    step_nix run "github:tek/hix#init" -- --name 'red-panda'
 
     step_run gen-cabal-quiet
 


### PR DESCRIPTION
https://github.com/tek/hix/pull/13 was merged, new main has `init` and `new` now, this test is testing the `init` command.