### PR TITLE
new command handle .. parent accessors

### DIFF
--- a/local.nix
+++ b/local.nix
@@ -26,6 +26,7 @@ in {
         "exceptions ^>= 0.10"
         "exon >= 1.4 && < 1.8"
         "extra ^>= 1.7"
+        "filepath"
         "filepattern ^>= 0.1"
         "generic-lens ^>= 2.2"
         "generics-sop ^>= 0.5"

--- a/packages/hix/hix.cabal
+++ b/packages/hix/hix.cabal
@@ -292,6 +292,7 @@ library
     , exceptions ==0.10.*
     , exon >=1.4 && <1.8
     , extra ==1.7.*
+    , filepath
     , filepattern ==0.1.*
     , generic-lens ==2.2.*
     , generics-sop ==0.5.*
@@ -406,6 +407,7 @@ test-suite hix-test
       Hix.Test.Managed.UnsafeIsString
       Hix.Test.ManagedTest
       Hix.Test.NewTest
+      Hix.Test.Optparse
       Hix.Test.PreprocTest
       Hix.Test.Utils
       Hix.Test.VersionTest

--- a/packages/hix/lib/Hix/Optparse.hs
+++ b/packages/hix/lib/Hix/Optparse.hs
@@ -50,13 +50,13 @@ absPathOrCwd ::
 absPathOrCwd desc cwd parse raw = 
   first (const [exon|not a valid #{desc} path: #{raw}|]) (parse raw') <&> \case
     Abs p -> p
-    Rel p -> foldr ($) cwd (replicate nbPrefixParents parent) </> p
+    Rel p -> foldr (const parent) cwd parents </> p
   where
     raw' :: String
-    raw' = intercalate [pathSeparator] $ drop nbPrefixParents parts
+    raw' = intercalate [pathSeparator] rest
 
-    nbPrefixParents :: Int
-    nbPrefixParents = length $ takeWhile (== "..") parts
+    parents, rest :: [String]
+    (parents, rest) = span (== "..") parts
 
     parts :: [String]
     parts = split isPathSeparator raw

--- a/packages/hix/test/Hix/Test/Optparse.hs
+++ b/packages/hix/test/Hix/Test/Optparse.hs
@@ -1,0 +1,33 @@
+module Hix.Test.Optparse where
+
+import Hedgehog ((===), evalEither)
+import Path (
+  Abs,
+  Path,
+  SomeBase(..),
+  absdir,
+  absfile,
+  parseSomeDir,
+  parseSomeFile,
+  )
+
+import Hix.Optparse (absPathOrCwd)
+import Hix.Test.Utils (UnitTest)
+
+test_absPathOrCwd :: UnitTest
+test_absPathOrCwd = do
+  doTest parseSomeDir "../dir" [absdir|/root/dir|]
+  doTest parseSomeDir "dir" [absdir|/root/base/dir|]
+  doTest parseSomeDir "/dir" [absdir|/dir|]
+  doTest parseSomeFile "../file.txt" [absfile|/root/file.txt|]
+  doTest parseSomeFile "file.txt" [absfile|/root/base/file.txt|]
+  doTest parseSomeFile "/file.txt" [absfile|/file.txt|]
+  where
+    doTest ::
+      (String -> Either e (SomeBase t)) ->
+      FilePath ->
+      Path Abs t ->
+      UnitTest
+    doTest parse raw expect = do
+      res <- evalEither $ absPathOrCwd "" [absdir|/root/base|] parse raw
+      res === expect

--- a/packages/hix/test/Main.hs
+++ b/packages/hix/test/Main.hs
@@ -7,6 +7,7 @@ import Hix.Test.CabalTest (test_cabal)
 import Hix.Test.GhciTest (test_ghci)
 import Hix.Test.ManagedTest (test_managed)
 import Hix.Test.NewTest (test_new)
+import Hix.Test.Optparse (test_absPathOrCwd)
 import Hix.Test.PreprocTest (
   test_preprocInsertPrelude,
   test_preprocNoPrelude,
@@ -38,7 +39,8 @@ tests =
     ],
     test_version,
     test_bounds,
-    test_managed
+    test_managed,
+    unitTest "path option parser" test_absPathOrCwd
   ]
 
 main :: IO ()

--- a/test/default.nix
+++ b/test/default.nix
@@ -51,6 +51,7 @@ let
       "bootstrap"
       "new"
       "new-with-name"
+      "new-parent-dir"
       "init"
       "init-static"
       "init-static-github"

--- a/test/new-parent-dir/test.nix
+++ b/test/new-parent-dir/test.nix
@@ -1,0 +1,26 @@
+{
+  root = false;
+  updateLock = false;
+
+  source = ''
+    mkdir -p root/dir
+    cd ./root/dir
+
+    step_nix run path:$hix_dir#cli -- new --hix-url="path:$hix_dir" --author 'Panda' '../red-panda'
+
+    cd ../red-panda
+
+    step_nix --quiet flake update
+
+    step_run gen-cabal-quiet
+
+    describe 'Run tests in generated project'
+    output_match 'passed 1 test'
+    error_ignore
+    step_ghci ghci -p red-panda -t main
+
+    describe 'Run app in generated project'
+    output_match 'Hello red-panda'
+    step_run
+  '';
+}


### PR DESCRIPTION
closes #15 

This works for ".." prefixes but doesn't work if there are other ".." in the path (e.g. `../dir/dir2/..`) because `path` library doesn't support it because it's hard to handle symlink cases. I guess it's a very specific use case which this might not really need to support.