### PR TITLE
Properly resolve user's path

### DIFF
--- a/packages/hix/hix.cabal
+++ b/packages/hix/hix.cabal
@@ -57,6 +57,7 @@ library
       Hix.Data.Overrides
       Hix.Data.PackageId
       Hix.Data.PackageName
+      Hix.Data.PathUser
       Hix.Data.PreprocConfig
       Hix.Data.ProjectFile
       Hix.Data.Version

--- a/packages/hix/lib/Hix/Data/NewProjectConfig.hs
+++ b/packages/hix/lib/Hix/Data/NewProjectConfig.hs
@@ -1,6 +1,6 @@
 module Hix.Data.NewProjectConfig where
 
-import Path (Abs, Dir, Path)
+import Hix.Data.PathUser (PathUser)
 
 newtype ProjectName =
   ProjectName { unProjectName :: Text }
@@ -42,7 +42,7 @@ data InitProjectConfig =
 
 data NewProjectConfig =
   NewProjectConfig {
-    directory :: Path Abs Dir,
+    directory :: PathUser,
     name :: Maybe ProjectName,
     printDirectory :: Bool,
     config :: NewProjectConfigCommon

--- a/packages/hix/lib/Hix/Data/PathUser.hs
+++ b/packages/hix/lib/Hix/Data/PathUser.hs
@@ -1,0 +1,23 @@
+module Hix.Data.PathUser where
+
+import Control.Monad.Trans.Reader (ask)
+import Path (Abs, Dir, File, Path)
+import Path.IO (resolveDir, resolveFile)
+
+import qualified Hix.Data.Monad
+import Hix.Data.Monad (AppResources (AppResources), M (M))
+import Hix.Monad (tryIOM)
+
+newtype PathUser = PathUser { unPathUser :: Text }
+  deriving stock (Eq, Show)
+  deriving newtype (IsString)
+
+resolvePathUserDir :: PathUser -> M (Path Abs Dir)
+resolvePathUserDir (PathUser path) = do
+  AppResources {cwd} <- M ask
+  tryIOM $ resolveDir cwd (toString path)
+
+resolvePathUserFile :: PathUser -> M (Path Abs File)
+resolvePathUserFile (PathUser path) = do
+  AppResources {cwd} <- M ask
+  tryIOM $ resolveFile cwd (toString path)

--- a/packages/hix/lib/Hix/New.hs
+++ b/packages/hix/lib/Hix/New.hs
@@ -15,6 +15,7 @@ import Text.Casing (pascal)
 
 import qualified Hix.Console as Console
 import qualified Hix.Data.NewProjectConfig
+import Hix.Data.PathUser (resolvePathUserDir)
 import Hix.Data.NewProjectConfig (
   Author,
   HixUrl (HixUrl),
@@ -191,12 +192,13 @@ initProject conf = traverse_ createFile =<< newProjectFiles conf
 
 newProject :: NewProjectConfig -> M ()
 newProject conf = do
+  directory <- resolvePathUserDir conf.directory
   let name =
         fromMaybe
-          (ProjectName . Text.dropWhileEnd (== '/') . Text.pack . fromRelDir . dirname $ conf.directory)
+          (ProjectName . Text.dropWhileEnd (== '/') . Text.pack . fromRelDir . dirname $ directory)
           conf.name
-  when conf.printDirectory $ Console.out (pathText conf.directory)
-  local (\res -> res { cwd = conf.directory }) $
+  when conf.printDirectory $ Console.out (pathText directory)
+  local (\res -> res { cwd = directory }) $
     initProject $ InitProjectConfig {name = name, config = conf.config}
 
 pathError :: Maybe a -> M a

--- a/packages/hix/lib/Hix/New.hs
+++ b/packages/hix/lib/Hix/New.hs
@@ -197,9 +197,9 @@ newProject conf = do
         fromMaybe
           (ProjectName . Text.dropWhileEnd (== '/') . Text.pack . fromRelDir . dirname $ directory)
           conf.name
-  when conf.printDirectory $ Console.out (pathText directory)
   local (\res -> res { cwd = directory }) $
     initProject $ InitProjectConfig {name = name, config = conf.config}
+  when conf.printDirectory $ Console.out (pathText directory)
 
 pathError :: Maybe a -> M a
 pathError = noteEnv "Can't convert project name to file path"

--- a/packages/hix/lib/Hix/Options.hs
+++ b/packages/hix/lib/Hix/Options.hs
@@ -27,6 +27,7 @@ import Options.Applicative (
   showDefault,
   showHelpOnEmpty,
   showHelpOnError,
+  str,
   strArgument,
   strOption,
   subparserInline,
@@ -101,7 +102,6 @@ import Hix.Optparse (
   maintHandlersOption,
   outputFormatOption,
   outputTargetOption,
-  pathUserOption,
   relFileOption,
   someFileOption,
   )
@@ -276,7 +276,7 @@ initParser = do
 
 newParser :: Parser NewOptions
 newParser = do
-  directory <- argument pathUserOption (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
+  directory <- argument str (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
   name <- optional projectNameParser
   printDirectory <- switch (long "print-dir" <> help "Print the created directory to stdout")
   config <- initCommonParser

--- a/packages/hix/lib/Hix/Options.hs
+++ b/packages/hix/lib/Hix/Options.hs
@@ -93,7 +93,6 @@ import qualified Hix.Managed.Data.StateFileConfig
 import Hix.Managed.Data.StateFileConfig (StateFileConfig (StateFileConfig))
 import Hix.Optparse (
   absDirOption,
-  absDirOrCwdOption,
   absFileOption,
   absFileOrCwdOption,
   buildHandlersOption,
@@ -102,6 +101,7 @@ import Hix.Optparse (
   maintHandlersOption,
   outputFormatOption,
   outputTargetOption,
+  pathUserOption,
   relFileOption,
   someFileOption,
   )
@@ -274,9 +274,9 @@ initParser = do
   config <- initCommonParser
   pure InitOptions {config = InitProjectConfig {..}}
 
-newParser :: Path Abs Dir -> Parser NewOptions
-newParser cwd = do
-  directory <- argument (absDirOrCwdOption cwd) (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
+newParser :: Parser NewOptions
+newParser = do
+  directory <- argument pathUserOption (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
   name <- optional projectNameParser
   printDirectory <- switch (long "print-dir" <> help "Print the created directory to stdout")
   config <- initCommonParser
@@ -430,7 +430,7 @@ commands cwd =
   <>
   command "init" (Init <$> info initParser (progDesc "Create a new Hix project in the current directory"))
   <>
-  command "new" (New <$> info (newParser cwd) (progDesc "Create a new Hix project in the specified directory"))
+  command "new" (New <$> info newParser (progDesc "Create a new Hix project in the specified directory"))
   <>
   command "bootstrap" (Bootstrap <$> info bootstrapParser (progDesc bootstrapDesc))
   <>

--- a/packages/hix/lib/Hix/Options.hs
+++ b/packages/hix/lib/Hix/Options.hs
@@ -6,7 +6,6 @@ import Options.Applicative (
   Mod,
   Parser,
   ReadM,
-  argument,
   auto,
   bashCompleter,
   command,
@@ -27,7 +26,6 @@ import Options.Applicative (
   showDefault,
   showHelpOnEmpty,
   showHelpOnError,
-  str,
   strArgument,
   strOption,
   subparserInline,
@@ -276,7 +274,7 @@ initParser = do
 
 newParser :: Parser NewOptions
 newParser = do
-  directory <- argument str (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
+  directory <- strArgument (metavar "DIR" <> help "Directory to create for the project, last component used as project name default")
   name <- optional projectNameParser
   printDirectory <- switch (long "print-dir" <> help "Print the created directory to stdout")
   config <- initCommonParser

--- a/packages/hix/lib/Hix/Optparse.hs
+++ b/packages/hix/lib/Hix/Optparse.hs
@@ -3,9 +3,10 @@ module Hix.Optparse where
 
 import Data.Aeson (eitherDecodeFileStrict', eitherDecodeStrict')
 import Data.List.Extra (split, stripInfix)
+import qualified Data.Text as Text
 import Distribution.Parsec (Parsec, eitherParsec)
 import Exon (exon)
-import Options.Applicative (ReadM, eitherReader)
+import Options.Applicative (ReadM, eitherReader, str)
 import Path (
   Abs,
   Dir,
@@ -26,6 +27,7 @@ import Path (
 import System.FilePath (isPathSeparator, pathSeparator)
 
 import Hix.Data.Json (JsonConfig (..))
+import Hix.Data.PathUser (PathUser (PathUser))
 import Hix.Data.OutputFormat (OutputFormat (..))
 import Hix.Data.OutputTarget (OutputTarget (..))
 import Hix.Managed.Cabal.ContextHackageRepo (fieldUpdater)
@@ -33,6 +35,9 @@ import Hix.Managed.Cabal.Data.ContextHackageRepo (ContextHackageRepo)
 import Hix.Managed.Cabal.Data.HackageRepo (HackageIndexState, HackageName)
 import Hix.Managed.Data.BuildConfig (SpecialBuildHandlers (..))
 import Hix.Managed.Data.SpecialMaintHandlers (SpecialMaintHandlers (..))
+
+pathUserOption :: ReadM PathUser
+pathUserOption = PathUser . Text.pack <$> str
 
 pathOption ::
   String ->

--- a/packages/hix/lib/Hix/Optparse.hs
+++ b/packages/hix/lib/Hix/Optparse.hs
@@ -3,10 +3,9 @@ module Hix.Optparse where
 
 import Data.Aeson (eitherDecodeFileStrict', eitherDecodeStrict')
 import Data.List.Extra (split, stripInfix)
-import qualified Data.Text as Text
 import Distribution.Parsec (Parsec, eitherParsec)
 import Exon (exon)
-import Options.Applicative (ReadM, eitherReader, str)
+import Options.Applicative (ReadM, eitherReader)
 import Path (
   Abs,
   Dir,
@@ -27,7 +26,6 @@ import Path (
 import System.FilePath (isPathSeparator, pathSeparator)
 
 import Hix.Data.Json (JsonConfig (..))
-import Hix.Data.PathUser (PathUser (PathUser))
 import Hix.Data.OutputFormat (OutputFormat (..))
 import Hix.Data.OutputTarget (OutputTarget (..))
 import Hix.Managed.Cabal.ContextHackageRepo (fieldUpdater)
@@ -35,9 +33,6 @@ import Hix.Managed.Cabal.Data.ContextHackageRepo (ContextHackageRepo)
 import Hix.Managed.Cabal.Data.HackageRepo (HackageIndexState, HackageName)
 import Hix.Managed.Data.BuildConfig (SpecialBuildHandlers (..))
 import Hix.Managed.Data.SpecialMaintHandlers (SpecialMaintHandlers (..))
-
-pathUserOption :: ReadM PathUser
-pathUserOption = PathUser . Text.pack <$> str
 
 pathOption ::
   String ->


### PR DESCRIPTION
This implements only the part for the `new` command, the directory argument and sets up the tooling for the rest I guess.

I was spending way too much time pondering in front of my monitor for the rest. Didn't really want to ask too many questions but I guess I was not moving at all so I will ask. I am very confused about all the path options there is in the `Hix.Optparse` module. Why some paths are expected to be relative, some other absolute and some other absolute or cwd? Can't they all be absolute or relative to the cwd?
Can't all [these](https://github.com/tek/hix/blob/main/packages/hix/lib/Hix/Optparse.hs#L37-L97) and all [these](https://github.com/tek/hix/blob/main/packages/hix/lib/Hix/Options.hs#L109-L124) be reduced to just a `pathUserOption` to be resolved later as introduced in this PR (or the sum type you suggested previously if we need for the tests later)?