### PR TITLE
Add OCs for shared libs and the special OC `__all`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 * Add OC `ghcOption` that only accepts a single string.
 * Default to `language = "Haskell2010"` to avoid eager evaluation of environment configs.
 * Add OC `noshared` that disables creation of shared libraries.
+* Add special treatment for the override named `__all`, applying to the result of `mkDerivation`, and therefore all
+  packages.
 
 # 0.9.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Unreleased
 
-* Changed the OC `ghcOptions` to accept a list of options as well as a string.
-* Added the OC `ghcOption` that only accepts a single string.
+* Change the OC `ghcOptions` to accept a list of options as well as a string.
+* Add OC `ghcOption` that only accepts a single string.
 * Default to `language = "Haskell2010"` to avoid eager evaluation of environment configs.
+* Add OC `noshared` that disables creation of shared libraries.
 
 # 0.9.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add OC `ghcOption` that only accepts a single string.
 * Default to `language = "Haskell2010"` to avoid eager evaluation of environment configs.
 * Add OC `noshared` that disables creation of shared libraries.
+* Add OC `shared` that enables linking Haskell libraries dynamically in executables.
 * Add special treatment for the override named `__all`, applying to the result of `mkDerivation`, and therefore all
   packages.
 

--- a/lib/deps/api.nix
+++ b/lib/deps/api.nix
@@ -52,6 +52,7 @@ let
     bench = transform_ "bench" modifiers.bench;
     nobench = transform_ "nobench" modifiers.nobench;
     noshared = transform_ "noshared" modifiers.noshared;
+    shared = transform_ "shared" modifiers.shared;
   };
 
   reset = drv null;

--- a/lib/deps/api.nix
+++ b/lib/deps/api.nix
@@ -51,6 +51,7 @@ let
     nodoc = transform_ "nodoc" modifiers.nodoc;
     bench = transform_ "bench" modifiers.bench;
     nobench = transform_ "nobench" modifiers.nobench;
+    noshared = transform_ "noshared" modifiers.noshared;
   };
 
   reset = drv null;

--- a/lib/deps/modifiers.nix
+++ b/lib/deps/modifiers.nix
@@ -19,6 +19,8 @@ let
 
   nodoc = hl.dontHaddock;
 
+  noshared = hl.disableSharedLibraries;
+
   minimal = p: noprofiling (nodoc (nobench (notest (unbreak p))));
 
   fast = p: noprofiling (nodoc p);
@@ -28,5 +30,5 @@ let
   force' = p: nodoc (force p);
 
 in {
-  inherit unbreak jailbreak profiling noprofiling minimal fast force force' notest bench nobench nodoc;
+  inherit unbreak jailbreak profiling noprofiling notest bench nobench nodoc noshared minimal fast force force';
 }

--- a/lib/deps/modifiers.nix
+++ b/lib/deps/modifiers.nix
@@ -21,6 +21,8 @@ let
 
   noshared = hl.disableSharedLibraries;
 
+  shared = hl.enableSharedExecutables;
+
   minimal = p: noprofiling (nodoc (nobench (notest (unbreak p))));
 
   fast = p: noprofiling (nodoc p);
@@ -30,5 +32,19 @@ let
   force' = p: nodoc (force p);
 
 in {
-  inherit unbreak jailbreak profiling noprofiling notest bench nobench nodoc noshared minimal fast force force';
+  inherit
+  unbreak
+  jailbreak
+  profiling
+  noprofiling
+  notest
+  bench
+  nobench
+  nodoc
+  noshared
+  shared
+  minimal
+  fast
+  force
+  force';
 }

--- a/lib/deps/pregen.nix
+++ b/lib/deps/pregen.nix
@@ -13,7 +13,7 @@
 
     result = ghc.override {
       overrides = self: super: let
-        os = deps.normalize overrides self super;
+        os = builtins.removeAttrs (deps.normalize overrides self super) ["__all"];
         decs = lib.concatMapAttrs (override self super) os;
       in decs // { __hix_pkgs = lib.attrNames os; };
     };

--- a/lib/deps/spec.nix
+++ b/lib/deps/spec.nix
@@ -56,7 +56,9 @@ let
   compile = specs: let
 
     check = acc: spec: specs:
-    if spec.type == "decl"
+    if !(spec ? type)
+    then throw "invalid override combinator without type attribute: ${lib.generators.toPretty {} spec}"
+    else if spec.type == "decl"
     then acc // { decl = spec; }
     else if spec.type == "transform"
     then spin (acc // { trans = acc.trans ++ [spec]; }) specs

--- a/lib/doc/prose.nix
+++ b/lib/doc/prose.nix
@@ -547,6 +547,11 @@ in {
   individual environment, and on the `ghc` module in an environment (although the latter is populated by Hix with the
   merged global and local overrides).
 
+  The special attribute name `__all` is recognized as a set of transformations applied to all packages – local as well
+  as dependencies, causing the latter to be rebuilt completely.
+  This works by overriding the package set attribute `mkDerivation` used by all packages (see below for details about
+  this function).
+
   ::: {.note}
   nixpkgs' shipped GHC package sets come with a few special derivations whose attribute names are suffixed with a
   concrete version, like `Cabal_3_10_2_1`, to be used as overrides for packages with incompatible requirements.

--- a/lib/doc/prose.nix
+++ b/lib/doc/prose.nix
@@ -707,6 +707,8 @@ in {
   - `bench` – Enable benchmarks
   - `nobench` – Disable benchmarks
   - `noshared` – Disable creation of shared libraries
+  - `shared` – Enable creation of executables that link dynamically against all Haskell dependencies (the default is to
+    only link dynamically against system libraries)
   - `minimal` – Unbreak and disable profiling libraries, Haddock, benchmarks and tests
   - `fast` – Disable profiling and Haddock
   - `force` – Unbreak, jailbreak and disable benchmarks and tests

--- a/lib/doc/prose.nix
+++ b/lib/doc/prose.nix
@@ -701,6 +701,7 @@ in {
   - `nodoc` – Disable Haddock
   - `bench` – Enable benchmarks
   - `nobench` – Disable benchmarks
+  - `noshared` – Disable creation of shared libraries
   - `minimal` – Unbreak and disable profiling libraries, Haddock, benchmarks and tests
   - `fast` – Disable profiling and Haddock
   - `force` – Unbreak, jailbreak and disable benchmarks and tests

--- a/modules/ghc.nix
+++ b/modules/ghc.nix
@@ -1,19 +1,21 @@
 { global, util }:
-{ lib, config, ... }:
-with lib;
-{
-  options = with types; {
-    name = mkOption {
-      type = str;
+{ lib, config, ... }: let
+
+  inherit (lib) types;
+
+in {
+  options = {
+    name = lib.mkOption {
+      type = types.str;
       description = "A unique identifier of the package set.";
     };
 
-    compiler = mkOption {
-      type = str;
+    compiler = lib.mkOption {
+      type = types.str;
       description = "The attribute name for a GHC version in the set `haskell.packages`.";
     };
 
-    overrides = mkOption {
+    overrides = lib.mkOption {
       type = util.types.cabalOverrides;
       description = ''
       The overrides used for this package set – see [](#ghc) for an explanation.
@@ -24,7 +26,7 @@ with lib;
       default = [];
     };
 
-    nixpkgs = mkOption {
+    nixpkgs = lib.mkOption {
       type = util.types.nixpkgs;
       description = ''
       The path to a nixpkgs source tree, used as the basis for the package set.
@@ -34,17 +36,17 @@ with lib;
     };
 
     # TODO make sure this is the type that recursively merges attrsets
-    nixpkgsOptions = mkOption {
-      type = attrsOf unspecified;
+    nixpkgsOptions = lib.mkOption {
+      type = types.attrsOf types.unspecified;
       description = "Additional options to pass to nixpkgs when importing.";
     };
 
-    pkgs = mkOption {
+    pkgs = lib.mkOption {
       type = util.types.pkgs;
       description = "The nixpkgs set used for this GHC.";
     };
 
-    crossPkgs = mkOption {
+    crossPkgs = lib.mkOption {
       type = util.types.pkgs;
       description = ''
       This option can be used to override the pkgs set used for the Haskell package set, for example an element of
@@ -52,37 +54,37 @@ with lib;
       '';
     };
 
-    overlays = mkOption {
-      type = listOf util.types.overlay;
+    overlays = lib.mkOption {
+      type = types.listOf util.types.overlay;
       description = "Additional nixpkgs overlays.";
     };
 
-    vanillaGhc = mkOption {
+    vanillaGhc = lib.mkOption {
       type = util.types.ghc;
       description = "The package set without overrides.";
       readOnly = true;
     };
 
-    ghc = mkOption {
+    ghc = lib.mkOption {
       type = util.types.ghc;
       description = "The package set with overrides.";
       readOnly = true;
     };
 
-    version = mkOption {
+    version = lib.mkOption {
       description = "The GHC version as a canonical string, like `9.2.5`, for use in conditions.";
-      type = str;
+      type = types.str;
       readOnly = true;
     };
 
-    gen-overrides = mkOption {
+    gen-overrides = lib.mkOption {
       description = ''
       Allow this GHC to use pregenerated overrides.
       Has no effect when [](#opt-general-gen-overrides.enable) is `false`.
 
       Disabled by default, but enabled for GHCs that are defined in an environment.
       '';
-      type = bool;
+      type = types.bool;
       default = false;
     };
 
@@ -95,17 +97,17 @@ with lib;
     nixpkgsOptions = util.unlessDev config global.envs.dev.ghc.nixpkgsOptions;
 
     pkgs = let
-      go = util.ghcOverlay { ghc = config; };
-      options = recursiveUpdate {
+      ghcOverlay = util.ghcOverlay { ghc = config; };
+      options = lib.recursiveUpdate {
         inherit (global) system;
-        overlays = [go] ++ config.overlays;
+        overlays = [ghcOverlay] ++ config.overlays;
         config.allowUnfree = true;
       } config.nixpkgsOptions;
     in import config.nixpkgs options;
 
-    crossPkgs = mkDefault config.pkgs;
+    crossPkgs = lib.mkDefault config.pkgs;
 
-    vanillaGhc = mkDefault (config.crossPkgs.haskell.packages.${config.compiler});
+    vanillaGhc = lib.mkDefault (config.crossPkgs.haskell.packages.${config.compiler});
 
     ghc = config.crossPkgs.hixPackages;
 


### PR DESCRIPTION
- **remove an open import**
- **OC: add `noshared`**
- **OC: apply override for `__all` to `mkDerivation`**
- **OC: add `shared`**
