### PR TITLE
Introduce extensible modules

### DIFF
--- a/lib/cabal-drv.nix
+++ b/lib/cabal-drv.nix
@@ -62,7 +62,10 @@ let
 
   in self.callPackage ({mkDerivation}: mkDerivation ({
     inherit pname;
-    src = srcWithCabal pkgs conf pname pkg.src;
+    src =
+      if config.genCabalInDerivations
+      then srcWithCabal pkgs conf pname pkg.src
+      else src;
     version = attr "version";
     license = attr "license";
     libraryHaskellDepends = deps (conf.library or {}) ++ compDeps "internal-libraries";

--- a/lib/internal/default.nix
+++ b/lib/internal/default.nix
@@ -2,6 +2,7 @@
 
   env = import ./env.nix { inherit util; };
   envs = import ./envs.nix { inherit util; };
+  modules = import ./modules.nix { inherit util; };
   package = import ./package.nix { inherit util; };
   packages = import ./packages.nix { inherit util; };
   project = import ./project.nix { inherit util; };

--- a/lib/internal/modules.nix
+++ b/lib/internal/modules.nix
@@ -1,6 +1,6 @@
 {util}: let
 
-  inherit (util) lib build;
+  inherit (util) lib build internal;
   inherit (lib) types;
 
   extendsDefault = lib.mkOverride 900;
@@ -157,6 +157,35 @@
   then api.${spec}
   else api spec;
 
+  deprecatedOptionDefined = loc: extra:
+  ''
+  The option '${lib.showOption loc}' is deprecated.
+  ${extra}
+  '';
+
+  deprecated = {type, key, replacement ? null, extra ? null}: type // {
+    name = "deprecated ${type.name}";
+    merge = loc: defs:
+      if lib.length defs == 1
+      then internal.warn.deprecatedOptionReadOnly {
+        inherit replacement extra key;
+        option = lib.showOption loc;
+      } (lib.head defs).value
+      else throw (deprecatedOptionDefined loc extra)
+      ;
+  };
+
+  deprecatedOption = {
+    type,
+    key,
+    replacement ? null,
+    extra ? null,
+    description ? "Deprecated.",
+  }: lib.mkOption {
+    inherit description;
+    type = deprecated { inherit type key replacement extra; };
+  };
+
 in {
   inherit
   extendsDefault
@@ -166,5 +195,6 @@ in {
   extensibleModule
   extensibleOption
   resolveExtensibleModule
+  deprecatedOption
   ;
 }

--- a/lib/internal/modules.nix
+++ b/lib/internal/modules.nix
@@ -1,0 +1,170 @@
+{util}: let
+
+  inherit (util) lib build;
+  inherit (lib) types;
+
+  extendsDefault = lib.mkOverride 900;
+
+  envDefault = lib.mkOverride 800;
+
+  pushableValue = value:
+  lib.isAttrs value
+  &&
+  !(
+    builtins.isPath value
+    ||
+    lib.isDerivation value
+    ||
+    lib.isStorePath value
+  )
+  ;
+
+  extendSpec = pushAttrs: name: value: let
+    next = pushAttrs.${name} or null;
+  in
+  if next == null
+  then extendsDefault value
+  else
+  if pushableValue value
+  then lib.mapAttrs (extendSpec next) value
+  else value
+  ;
+
+  extendsConfig = {remove ? [], attr, options, target, pushDefault}: let
+    default = util.config.${attr}.${target};
+
+    extend = pushAttrs: optionName: option: let
+      value = default.${optionName};
+
+      next = pushAttrs.${optionName} or null;
+
+    in if
+    pushableValue value
+    &&
+    (
+      option.type.name == "attrsOf"
+      ||
+      option.type.name == "submodule"
+      ||
+      pushAttrs ? ${optionName}
+    )
+    then lib.mapAttrs (extendSpec next) value
+    else extendsDefault value;
+
+    allowed = util.removeKeys (remove ++ ["name" "extends"]) options;
+
+  in lib.mkIf (target != null) (lib.mapAttrs (extend pushDefault) allowed);
+
+  extendsOption = {attr, type}: lib.mkOption {
+    description = ''
+    The name of another entry in [](#opt-general-${attr}) whose config values will be used as defaults for this one.
+    '';
+    type = types.nullOr type;
+    default = "default";
+  };
+
+  extensibleName = {name, extends, extender}: let
+
+    actual =
+      if extender != null
+      then
+      if extends != null && extends != "default"
+      then "${extender}-extends-${extends}"
+      else extender
+      else name
+      ;
+
+  in lib.mkIf (name != null || extender != null) (lib.mkDefault actual);
+
+  extensibleModule = {
+    id,
+    attr ? "${id}s",
+    type ? util.types.ref.${id},
+    name,
+    config,
+    options,
+    extraConfig ? {},
+    remove ? [],
+    pushDefault ? {},
+  }: {
+
+    options = options // {
+
+      name = lib.mkOption {
+        description = ''
+        The name of this configuration is derived from the attribute when it's defined in [](#opt-general-${attr}), and
+        from the containing module if it is extended.
+        Should not be overridden.
+        '';
+        type = types.str;
+      };
+
+      extends = extendsOption { inherit attr type; };
+
+      extender = util.maybeOption types.str {
+        description = ''
+        The name of the containing module if this module is extended.
+        '';
+      };
+
+    };
+
+    config =
+      lib.mkMerge [
+        (extendsConfig { inherit attr options remove pushDefault; target = config.extends; })
+        {
+          name = extensibleName { inherit name; inherit (config) extends extender; };
+        }
+        extraConfig
+      ];
+
+  };
+
+  extensibleOption = {module, type, attr, desc, extender, ref ? true}: let
+
+    moduleType = types.submoduleWith { modules = [module { inherit extender; }]; };
+
+    entryDesc = "an entry in [](#opt-general-${attr}) ${desc}";
+
+    defaultExplanation = ''
+    options will default to the config in `${attr}.default`; or if the option `extends` is set in the submodule, the
+    config in `${attr}` by that name
+    '';
+
+  in if ref
+  then lib.mkOption {
+    description = ''
+    The name of ${entryDesc}.
+    Alternatively, this may be specified as submodule configuration of that type, in which case all
+    ${defaultExplanation}.
+    '';
+    type = types.either type moduleType;
+    default = "default";
+  }
+  else lib.mkOption {
+    description = ''
+    An submodule extending ${entryDesc}.
+    All ${defaultExplanation}.
+    '';
+    type = moduleType;
+    default = {};
+  };
+
+  resolveExtensibleModule = type: spec: let
+    api = build.${type};
+  in
+  if builtins.isString spec
+  then api.${spec}
+  else api spec;
+
+in {
+  inherit
+  extendsDefault
+  envDefault
+  extendsConfig
+  extendsOption
+  extensibleModule
+  extensibleOption
+  resolveExtensibleModule
+  ;
+}

--- a/modules/basic.nix
+++ b/modules/basic.nix
@@ -90,35 +90,28 @@ in {
       default = {};
     };
 
+    ifd = mkOption {
+      description = ''
+      Whether to use `cabal2nix`, which uses Import From Derivation, or to generate simple derivations, for local
+      packages.
+      '';
+      type = bool;
+      default = false;
+    };
+
+    genCabalInDerivations = lib.mkOption {
+      description = ''
+      Whether [Hix-generated derivations](#no-ifd) should synthesize Cabal files from [](#opt-general-packages).
+      '';
+      type = types.bool;
+      default = true;
+    };
+
     # TODO cli must be able to resolve components from metadata by reading cabal.project and *.cabal
     manualCabal = mkOption {
       description = ''
       Don't use the options in [](#opt-general-packages) as Cabal configuration for the ghci preprocessor and search
       path assembler.
-      '';
-      type = bool;
-      default = false;
-    };
-
-    forceCabal2nix = mkOption {
-      description = "Whether to use cabal2nix even if there is no Cabal file.";
-      type = bool;
-      default = false;
-    };
-
-    # TODO is this effective and desired?
-    forceCabalGen = mkOption {
-      description = ''
-      Whether to generate a Cabal file from Nix config even if there is one in the source directory.
-      '';
-      type = bool;
-      default = false;
-    };
-
-    ifd = mkOption {
-      description = ''
-      Whether to use `cabal2nix`, which uses Import From Derivation, or to generate simple derivations, for local
-      packages.
       '';
       type = bool;
       default = false;

--- a/test/internal/step.zsh
+++ b/test/internal/step.zsh
@@ -294,13 +294,17 @@ _step_check_combined()
 _step_diff()
 {
   local actual_file=$1 expected=$2 headline=$3
-  local expected_desc=''
+  local expected_desc='' diff_options=()
+  if (( ${+_step_diff_ignore_trailing_space} == 1 ))
+  then
+    diff_options+=(--ignore-trailing-space)
+  fi
   if [[ -f $expected ]]
   then
     expected_desc=" [$(color_path $(_unclutter_store_path <<< $expected))]"
-    diff $expected $actual_file &> $step_diff
+    diff $expected $actual_file $=diff_options &> $step_diff
   else
-    diff <(print -- $expected) $actual_file &> $step_diff
+    diff <(print -- $expected) $actual_file $=diff_options &> $step_diff
   fi
   if (( $? != 0 ))
   then
@@ -605,6 +609,7 @@ step()
     _step_preproc_files \
     _step_allow_failure \
     _step_combined_output \
+    _step_diff_ignore_trailing_space \
     _step_validated_out \
     _step_validated_err \
     _step_description
@@ -756,6 +761,11 @@ error_ignore()
 describe()
 {
   _step_description="$*"
+}
+
+diff_ignore_trailing_space()
+{
+  _step_diff_ignore_trailing_space=1
 }
 
 # Output preprocessors


### PR DESCRIPTION
- **add option `genCabalInDerivations` to allow using manual Cabal config with ifd-less derivations**
- **test: add `diff_ignore_trailing_space`**
- **modules: introduce a general mechanism for options that may refer to or extend existing configurations**
- **modules: constructor for deprecated options**
