### PR TITLE
Add option `shellTools` for shells and commands and add all `buildInputs` to derivations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,10 @@
 * Add the options `envs.*.ghci{,d}.args` as env-specific extra arguments to those commands, based on env selection.
 * Add the options `ghci{,d}.args` as unconditional extra arguments to those commands.
 * Add the CLI option `--env` to override env selection for commands.
+* The packages defined by the option `envs.*.buildInputs` are now provided to local package derivations as well, for
+  consistency with other options of that name.
+* Add the options `shellTools` and `envs.*.shellTools` to take on the previous role of `envs.*.buildInputs` for packages
+  that should not be made available to local package derivations.
 
 # 0.9.0
 

--- a/lib/cabal-drv.nix
+++ b/lib/cabal-drv.nix
@@ -1,4 +1,4 @@
-{config, lib, env}:
+{config, lib, envName}:
 let
 
   hpackFile = conf:
@@ -45,7 +45,7 @@ let
     if lib.hasAttr n self
     then self.${n}
     else
-    throw "The Cabal config for '${pname}' in the env '${env}' has a dependency on the nonexistent package '${n}'.";
+    throw "The Cabal config for '${pname}' in the env '${envName}' has a dependency on the nonexistent package '${n}'.";
 
     depspec = spec: let
       name = depPkg spec;

--- a/lib/deps/local.nix
+++ b/lib/deps/local.nix
@@ -4,13 +4,14 @@
   libraryProfiling,
   profiling,
   localPackage,
-  env,
+  envName,
   packages,
+  buildInputs,
 }:
 let
   inherit (util) config lib;
 
-  cabalDrv = import ../cabal-drv.nix { inherit config lib env; };
+  cabalDrv = import ../cabal-drv.nix { inherit config lib envName; };
 
   localProfiling = api:
   if profiling
@@ -20,17 +21,13 @@ let
   then api.id
   else api.noprofiling;
 
-  buildInputs = api: opt:
-  if lib.isFunction opt
-  then opt api.pkgs
-  else opt;
-
   override = api: pkg:
   lib.pipe (localProfiling api) [
     (localPackage api)
     (pkg.override api)
-    (api.buildInputs (buildInputs api pkg.buildInputs))
-    (api.buildInputs (buildInputs api config.buildInputs))
+    (api.buildInputs (pkg.buildInputs api.pkgs))
+    (api.buildInputs (buildInputs api.pkgs))
+    (api.buildInputs (config.buildInputs api.pkgs))
   ];
 
   checkIfd = api: name: pkg:

--- a/lib/doc/chapters.nix
+++ b/lib/doc/chapters.nix
@@ -97,6 +97,7 @@
     (options.importMod "commands" { inherit config lib util; })
     (options.importMod "overrides" { inherit config lib util; })
     (options.importMod "output" { inherit config lib util; inherit (util) outputs; })
+    (options.importMod "build-tools" { inherit config lib util; })
   ];
   generalExclude = [
     { type = "sub"; path = ["envs"]; }

--- a/lib/doc/prose.nix
+++ b/lib/doc/prose.nix
@@ -509,7 +509,7 @@ in {
 
         compiler = "ghc94";
 
-        buildInputs = [config.pkgs.socat];
+        shellTools = pkgs: [pkgs.socat];
 
         services.postgres = {
           enable = true;

--- a/lib/internal/command.nix
+++ b/lib/internal/command.nix
@@ -1,7 +1,7 @@
 {util}:
 let
 
-  inherit (util) lib internal outputs;
+  inherit (util) lib outputs;
 
   cli = util.config.internal.hixCli.exe;
 
@@ -52,7 +52,7 @@ let
 
     path = util.script "hix-command-${env.name}-${command.name}" ''
     set -u
-    export PATH="${lib.makeBinPath (internal.env.mkBuildInputs env command.buildInputs)}:$PATH"
+    export PATH="${lib.makeBinPath (command.buildInputs env.toolchain.pkgs)}:$PATH"
     ${self.script}
     '';
 

--- a/lib/internal/env.nix
+++ b/lib/internal/env.nix
@@ -87,16 +87,15 @@
     os = internal.managed.state.current.solver.${envName} or {};
   in lib.mapAttrs (managedOverride api) os;
 
-  mkBuildInputs = env: spec:
-  if lib.isFunction spec
-  then spec env.toolchain.pkgs
-  else spec;
-
-  buildInputs = env:
-  mkBuildInputs env env.buildInputs ++
-  mkBuildInputs env config.buildInputs ++
-  env.haskellTools env.toolchain.vanilla ++
-  config.haskellTools env.toolchain.vanilla ++
+  buildInputs = env: let
+    inherit (env.toolchain) pkgs vanilla;
+  in
+  env.buildInputs pkgs ++
+  config.buildInputs pkgs ++
+  env.shellTools pkgs ++
+  config.shellTools pkgs ++
+  env.haskellTools vanilla ++
+  config.haskellTools vanilla ++
   lib.optional env.hls.enable env.hls.package ++
   lib.optional env.ghcid.enable env.ghcid.package ++
   [env.ghcWithPackages]
@@ -172,7 +171,6 @@ in {
   isTarget
   managedOverrides
   managedSolverOverrides
-  mkBuildInputs
   buildInputs
   validate
   mapValidatedOutputs

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -227,4 +227,22 @@ in {
 
   password = types.either types.str (submodule passwordModule);
 
+  listOrFunction = elemType: let
+
+    listType = types.listOf elemType;
+    functionType = types.functionTo listType;
+    eitherType = types.either listType functionType;
+
+  in mkOptionType {
+    name = "listOrFunction";
+    description = "list of ${
+      types.optionDescriptionPhrase (class: class == "noun" || class == "composite") elemType
+    } or function returning such a list";
+    descriptionClass = "composite";
+    inherit (eitherType) check;
+
+    merge = loc: defs:
+    functionType.merge loc (map (def: if lib.isFunction def.value then def else (def // { value = _: def.value; })) defs);
+  };
+
 }

--- a/modules/basic.nix
+++ b/modules/basic.nix
@@ -194,18 +194,33 @@ in {
       '';
     };
 
+    shellTools = mkOption {
+      description = ''
+      Packages that should be included in every environment's `$PATH`.
+      The argument passed to the function is the environment's nixpkgs set.
+
+      If you want to include a tool that's not specific to the environment, you can also ignore the argument and use the
+      [global pkgs](opt-general-pkgs) or any other source of packages.
+
+      The default consists of `cabal-install` (from [](#opt-general-build-tools.cabal.package)), since that's a crucial
+      tool most users would expect to be available.
+      If you want to provide a custom `cabal-install` package for environments only (rather than overriding
+      [](#opt-general-build-tools.cabal.package)), you'll have to set `shellTools = lib.mkForce (...)`, since the
+      built-in definition doesn't use `mkDefault` to ensure that adding tools in your project won't mysteriously remove
+      `cabal-install` from all shells.
+      '';
+      type = types.functionTo (types.listOf types.package);
+    };
+
     haskellTools = mkOption {
       description = ''
-      Function returning a list of names of Haskell packages that should be included in every environment's `$PATH`.
+      Haskell packages that should be included in every environment's `$PATH`.
       This is a convenience variant of [](#opt-env-buildInputs) that provides the environment's GHC package set (without
       overrides) as a function argument.
       This is intended for tooling like `fourmolu`.
-      The default consists of `cabal-install`, since that's a crucial tool most users would expect to be available.
-      If you want to provide a custom `cabal-install` package, you'll have to set `haskellTools = lib.mkForce (...)`,
-      since the built-in definition doesn't use `mkDefault` to ensure that adding tools in your project won't
-      mysteriously remove `cabal-install` from all shells.
       '';
       type = types.functionTo (types.listOf types.package);
+      default = _: [];
       example = literalExpression ''ghc: [ghc.fourmolu]'';
     };
 
@@ -318,7 +333,7 @@ in {
 
     pkgs = lib.mkDefault util.pkgs;
 
-    haskellTools = ghc: [ghc.cabal-install];
+    shellTools = _: [config.build-tools.cabal.package];
 
     internal = {
 

--- a/modules/command.nix
+++ b/modules/command.nix
@@ -37,8 +37,11 @@ in {
     };
 
     buildInputs = lib.mkOption {
-      description = "Packages that should be in `$PATH` for this command.";
-      type = types.either (types.functionTo (types.listOf types.package)) (types.listOf types.package);
+      description = ''
+      Additional packages that should be included in this command's `$PATH`.
+      The argument passed to the function is the nixpkgs set of the environment in which the command is run.
+      '';
+      type = util.types.listOrFunction types.package;
       default = [];
     };
 

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -172,12 +172,10 @@ in {
 
     buildInputs = lib.mkOption {
       description = ''
-      Additional system package dependencies for this environment.
-      ::: {.note}
-      These are only made available to shells and commands, not added to packages, like when they are set in overrides.
-      :::
+      Additional non-Haskell dependencies provided to all packages in this environment.
+      The argument is the this environment's nixpkgs set.
       '';
-      type = either (functionTo (listOf package)) (listOf package);
+      type = util.types.listOrFunction package;
       default = [];
     };
 
@@ -191,10 +189,19 @@ in {
       default = [];
     };
 
+    shellTools = lib.mkOption {
+      description = ''
+      Packages that should be included in the environment's `$PATH`.
+      The argument passed to the function is the environment's nixpkgs set.
+      '';
+      type = types.functionTo (types.listOf types.package);
+      default = _: [];
+    };
+
     haskellTools = lib.mkOption {
       description = ''
-      Function returning a list of names of Haskell packages that should be included in the environment's `$PATH`.
-      This is a convenience variant of [](#opt-env-buildInputs) that provides the environment's GHC package set (without
+      Haskell packages that should be included in the environment's `$PATH`.
+      This is a convenience variant of [](#opt-env-shellTools) that provides the environment's GHC package set (without
       overrides) as a function argument.
       This is intended for tooling like `fourmolu`.
       '';
@@ -643,8 +650,8 @@ in {
 
         overridesLocal = import ../lib/deps/local.nix {
           inherit util;
-          inherit (config) ifd localPackage libraryProfiling profiling;
-          env = config.name;
+          inherit (config) ifd localPackage libraryProfiling profiling buildInputs;
+          envName = config.name;
           packages =
             if config.localOverrides == "targets"
             then util.restrictKeys (internal.env.targets config) global.packages

--- a/modules/overrides.nix
+++ b/modules/overrides.nix
@@ -22,8 +22,11 @@ in {
     };
 
     buildInputs = mkOption {
-      description = "Additional non-Haskell dependencies provided to all packages and environments.";
-      type = types.either (types.functionTo (types.listOf types.package)) (types.listOf types.package);
+      description = ''
+      Additional non-Haskell dependencies provided to all packages and environments.
+      The argument is the active environment's nixpkgs set.
+      '';
+      type = util.types.listOrFunction types.package;
       default = [];
     };
 

--- a/modules/package.nix
+++ b/modules/package.nix
@@ -289,7 +289,7 @@ in {
 
     buildInputs = mkOption {
       description = "Additional non-Haskell dependencies required by this package.";
-      type = types.either (types.functionTo (types.listOf types.package)) (types.listOf types.package);
+      type = util.types.listOrFunction types.package;
       default = [];
     };
 

--- a/test/command/root/flake.nix
+++ b/test/command/root/flake.nix
@@ -12,7 +12,7 @@
   in {
 
     envs.dev = {
-      buildInputs = [(dummy "env-input")];
+      buildInputs = _: [(dummy "env-input")];
     };
 
     commands.inputs = {


### PR DESCRIPTION
use `shellTools` to provide `cabal-install`
